### PR TITLE
Handle ConfigMounts, create default zot-config

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(wsl -e bash -c:*)",
+      "Bash(dotnet --version:*)",
+      "Bash(dotnet publish:*)"
+    ]
+  }
+}


### PR DESCRIPTION
Add handling for ConfigMounts in init.sh: create ~/.vega/ConfigMounts, remove incorrectly created directories, copy ConfigMounts from the release, and ensure zot-config.json exists (copy from release or create a sensible default). Introduce a cleanup helper to remove directories accidentally created by Docker file mounts and ensure ~/.vega/ConfigMounts and ~/.vega/Certs exist. Also add .claude/settings.local.json to allow specific Bash commands for local Claude integrations.
